### PR TITLE
Ansible 2.3.1 regression

### DIFF
--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -12,7 +12,7 @@
   become: yes
   become_user: "{{ fubarhouse_user }}"
   shell:  "{{ nvm_symlink_exec }} install {{ item }}"
-  when: '"{{ item }}" in nodejs_available_versions.stdout and item not in installed_nodejs_versions.stdout'
+  when: '"node_version" in nodejs_available_versions.stdout and "node_version" not in "node_versions" and "node_version" not in "installed_nodejs_versions.stdout"'
   with_items:
   - "{{ node_version }}"
   - "{{ node_versions }}"


### PR DESCRIPTION
Received this error with ansible 2.3.1 but not with 2.3.0.

```
TASK [fubarhouse.nodejs : NodeJS | Install default version] ********************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: "{{ node_version }}" in
nodejs_available_versions.stdout and "{{ node_version }}" not in "{{
node_versions }}" and "{{ node_version }}" not in "{{
installed_nodejs_versions.stdout }}"

fatal: [barista_vumc_mcdev]: FAILED! => {"failed": true, "msg": "The conditional check '\"{{ node_version }}\" in nodejs_available_versions.stdout and \"{{ node_version }}\" not in \"{{ node_versions }}\" and \"{{ node_version }}\" not in \"{{ installed_nodejs_versions.stdout }}\"' failed. The error was: Invalid conditional detected: EOL while scanning string literal (<unknown>, line 1)\n\nThe error appears to have been in '/Users/jstewart/src/vu/vumc_barista/vendor/mediacurrent/mis_vagrant/provisioning/roles/fubarhouse.nodejs/tasks/nodejs.yml': line 11, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"NodeJS | Install default version\"\n  ^ here\n"}
```