### PR TITLE
Release for 1.8.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,8 +29,3 @@ node_packages:
   - replace
   - underscore
   - yosay
-
-nodejs_folder_paths:
-  - path: "/usr/local/lib/node_modules"
-  - path: "{{ fubarhouse_user_dir }}/.npm"
-  - path: "{{ fubarhouse_user_dir }}/.nvm"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,5 +32,5 @@ node_packages:
 
 nodejs_folder_paths:
   - path: "/usr/local/lib/node_modules"
-  - path: "/Users/{{ fubarhouse_user }}/.npm"
-  - path: "/Users/{{ fubarhouse_user }}/.nvm"
+  - path: "{{ fubarhouse_user_dir }}/.npm"
+  - path: "{{ fubarhouse_user_dir }}/.nvm"

--- a/tasks/iojs.yml
+++ b/tasks/iojs.yml
@@ -18,7 +18,7 @@
   register: fubarhouse_npm_io_install_result
   changed_when: false
   failed_when: false
-  when: '"{{ node_version }}" in iojs_available_versions.stdout_lines'
+  when: 'node_version in iojs_available_versions.stdout_lines'
 
 - name: "IOJS | Check for all local installs"
   stat:
@@ -26,7 +26,7 @@
   register: fubarhouse_npm_io_install_results
   changed_when: false
   failed_when: false
-  when: '"{{ item }}" in iojs_available_versions.stdout'
+  when: 'item in iojs_available_versions.stdout'
   with_items: "{{ node_versions }}"
 
 - name: "IOJS | Install default"
@@ -48,7 +48,7 @@
   shell: "{{ nvm_symlink_exec }} unalias default"
   changed_when: false
   failed_when: false
-  when: '"{{ node_version }}" in iojs_available_versions.stdout'
+  when: 'node_version in iojs_available_versions.stdout'
 
 - name: "IOJS | Switch"
   file:
@@ -56,11 +56,11 @@
     dest: "/usr/local/bin/iojs"
     state: link
     force: yes
-  when: '"{{ node_version }}" in iojs_available_versions.stdout'
+  when: 'node_version in iojs_available_versions.stdout'
 
 - name: "IOJS | Verify version in use"
   shell: "/usr/local/bin/ivm ls | grep ο | cat"
   register: iojs_current_version
   changed_when: false
   failed_when: 'iojs_current_version.stdout.find("{{ node_version }}") == -1'
-  when: '"{{ node_version }}" in iojs_available_versions.stdout'
+  when: 'node_version in iojs_available_versions.stdout'

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -8,7 +8,7 @@
 
 - name: "NodeJS | Install all requested versions"
   shell:  "{{ nvm_symlink_exec }} install {{ item }}"
-  when: '"{{ item }}" in nodejs_available_versions.stdout and item not in installed_nodejs_versions.stdout'
+  when: 'item in nodejs_available_versions.stdout and item not in installed_nodejs_versions.stdout'
   with_items:
   - "{{ node_version }}"
   - "{{ node_versions }}"
@@ -17,12 +17,12 @@
   shell:  "{{ nvm_symlink_exec }} use --delete-prefix {{ node_version }}"
   register: fubarhouse_npm_switch
   changed_when: false
-  when: '"{{ node_version }}" in nodejs_available_versions.stdout'
+  when: 'node_version in nodejs_available_versions.stdout'
 
 - name: "NodeJS | Linking"
   shell: "{{ nvm_symlink_exec }} alias default {{ node_version }}"
   changed_when: false
-  when: '"{{ node_version }}" in nodejs_available_versions.stdout'
+  when: 'node_version in nodejs_available_versions.stdout'
 
 - name: "NodeJS | Linking binaries"
   file:
@@ -33,7 +33,7 @@
   with_items:
     - node
     - npm
-  when: '"{{ node_version }}" in nodejs_available_versions.stdout'
+  when: 'node_version in nodejs_available_versions.stdout'
   changed_when: false
 
 - name: "NodeJS | Import exports"
@@ -50,4 +50,4 @@
   register: node_current_version
   changed_when: false
   failed_when: 'node_current_version.stdout.find("{{ node_version }}") == -1'
-  when: '"{{ node_version }}" in nodejs_available_versions.stdout'
+  when: 'node_version in nodejs_available_versions.stdout'

--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -57,12 +57,15 @@
 
 - name: "NVM | Ensure permissions are set"
   file:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     state: directory
     mode: 0777
     owner: "{{ fubarhouse_user }}"
     recurse: no
-  with_items: "{{ nodejs_folder_paths }}"
+  with_items:
+    - "/usr/local/lib/node_modules"
+    - "{{ fubarhouse_user_dir }}/.npm"
+    - "{{ fubarhouse_user_dir }}/.nvm"
   changed_when: false
 
 - name: "NVM | Get distribution"


### PR DESCRIPTION
* Changes node_folder_paths to literal. Raised in #46.
* Changes value of node_folder_paths to support $HOME and not MacOS conventions by default. Raised in #46.
* Adjust when conditions to not include Jinja2 interpolation. Raised in #46.