### PR TITLE
Deprecated stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services: docker
 
 env:
 
+  # Source installation tests.
   - distro: precise
     init: /sbin/init
     run_opts: --privileged
@@ -43,10 +44,10 @@ env:
     init: /sbin/init
     run_opts: --privileged
     playbook: playbook.yml
-#  - distro: yakkety
-#    init: /sbin/init
-#    run_opts: --privileged
-#    playbook: playbook.yml
+  - distro: yakkety
+    init: /sbin/init
+    run_opts: --privileged
+    playbook: playbook.yml
   - distro: zesty
     init: /sbin/init
     run_opts: --privileged
@@ -99,6 +100,10 @@ env:
     init: /usr/lib/systemd/systemd
     run_opts: --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
     playbook: playbook.yml
+  - distro: fedora-28
+    init: /usr/lib/systemd/systemd
+    run_opts: --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro
+    playbook: playbook.yml
 
 before_install:
 
@@ -121,7 +126,7 @@ script:
   - idempotence=$(mktemp)
   - >
     docker exec "$(cat ${container_id})"
-    ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook} --sudo -vvvv
+    ansible-playbook /etc/ansible/roles/role_under_test/tests/${playbook} --sudo
     | tee -a ${idempotence}
   - >
     tail ${idempotence}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Default Node version
 ````yaml
-node_version: 9.7.1
+node_version: 10.0.0
 ````
 
 All Node versions to install
@@ -29,7 +29,8 @@ node_versions:
   - 5.12.0
   - 6.10.2
   - 7.9.0
-  = 8.9.1
+  - 8.9.1
+  - 9.7.1
 ````
 
 Node packages to download

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,13 +16,14 @@ install_ivm: false
 install_iojs: false
 install_npm: true
 
-node_version: 9.7.1
+node_version: 10.0.0
 node_versions:
   - 4.8.2
   - 5.12.0
   - 6.11.2
   - 7.9.0
   - 8.9.1
+  - 9.7.1
 
 node_packages:
   - backbone

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: fubarhouse
   description: Installs NVM, NodeJS and NPM packages.
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.1.0.0
+  min_ansible_version: 2.4
   platforms:
     - name: Debian
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
         - 25
         - 26
         - 27
+        - 28
     - name: Ubuntu
       versions:
         - precise
@@ -34,7 +35,7 @@ galaxy_info:
         - wily
         - vivid
         - xenial
-#        - yakkety
+        - yakkety
         - zesty
         - artful
         - bionic

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Main tasks file for fubarhouse.nodejs
 
-- include: setup.yml
+- include_tasks: setup.yml
 
 - name: "Set default ivm installation directory"
   set_fact:
@@ -17,17 +17,17 @@
   - nvm_install_dir is not defined
   - install_nvm|bool == true
 
-- include: nvm.yml
+- include_tasks: nvm.yml
   when: install_nvm
 
-- include: ivm.yml
+- include_tasks: ivm.yml
   when: install_ivm|bool == true
 
-- include: nodejs.yml
+- include_tasks: nodejs.yml
   when: install_nodejs|bool == true
 
-- include: iojs.yml
+- include_tasks: iojs.yml
   when: install_iojs|bool == true
 
-- include: npm.yml
+- include_tasls: npm.yml
   when: install_npm|bool == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,5 @@
 - include_tasks: iojs.yml
   when: install_iojs|bool == true
 
-- include_tasls: npm.yml
+- include_tasks: npm.yml
   when: install_npm|bool == true


### PR DESCRIPTION
* Re-adds support for Yakkety
* Adds support for Fedora 28
* Bumps required version to Ansible 2.4
* Removes deprecated use of `include`