### PR TITLE
fix: Become root on 'Linking binaries'

### DIFF
--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -25,6 +25,8 @@
   when: 'node_version in nodejs_available_versions.stdout'
 
 - name: "NodeJS | Linking binaries"
+  become: yes
+  become_user: root
   file:
     src: "{{ nvm_install_dir }}/versions/node/v{{ node_version }}/bin/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"


### PR DESCRIPTION
Creating the binary links in /usr/local/bin requires sudo permissions.

Modified this task to become root to ensure links are created even
when role is run as non-root user.