### PR TITLE
DNF is not available for Amazon linux

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -14,7 +14,7 @@
     - tar
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution == "CentOS"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "Amazon")
 
 - name: "NodeJS | Install dependencies (Debian)"
   apt:
@@ -44,4 +44,4 @@
     - tar
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution != "CentOS"
+    - (ansible_distribution != "CentOS" and ansible_distribution != "Amazon")


### PR DESCRIPTION
This role currently fails when you run it against an Amazon Linux instance because DNF is not available and the default package manager is YUM. This change will prevent that to happen.