### PR TITLE
Fix for NVM profiles configuration

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -149,7 +149,7 @@
 
 - name: NVM | Ensure shell profiles are available
   stat:
-    path: "~/{{ item }}"
+    path: "~/{{ item.item }}"
   register: available_shell_profiles
   with_items: "{{ available_shell_profiles.results }}"
   failed_when: false


### PR DESCRIPTION
I was getting `Filename too long!` so I looked into it and `item` was containing an object with an `item` argument.

Tested on ansible 2.7.10 & python 2.7.5.