### PR TITLE
Don't overwrite `NVM_NODEJS_ORG_MIRROR`

### DIFF
--- a/templates/nvm.sh
+++ b/templates/nvm.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
-export NVM_NODEJS_ORG_MIRROR=http://nodejs.org/dist;
 source {{ nvm_install_dir }}/nvm.sh && nvm "$@";


### PR DESCRIPTION
There doesn't seem to be a point to overwriting `NVM_NODEJS_ORG_MIRROR` variable here, especially since there's a default within `nvm.sh`: https://github.com/nvm-sh/nvm/blob/45c1b84794d446dd8274938c8259cbfd8b846e47/nvm.sh#L1676.

If there was value in overwriting it here, `export NVM_NODEJS_ORG_MIRROR={{ nvm_nodejs_org_mirror_url | default("https://nodejs.org/dist") }}` would work so the value could be customized, but it seems unnecessary since there's a default in nvm.sh and the environment variable can be set by the user when actually using nvm, not hard-coded here.