### PR TITLE
 #98 Update NVM version identifier

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ shell_profiles:
   - .bash_profile
 nodejs_clean_install: false
 nvm_symlink_dir: /usr/local/bin
-nvm_version: v0.33.8
+nvm_version: v0.34.0
 
 #nvm_repo: "https://github.com/xtuple/nvm.git"
 ivm_repo: "https://github.com/demohi/ivm.git"


### PR DESCRIPTION
Updates NVM to the latest release (`v0.34.0`).

Resolves #98 

* Git version requirement has deemed #99 to be necessary for this change.
* EOL Debian Wheezy is no longer supportable/buildable so support has been removed (#96).